### PR TITLE
fix hackage build and reduce dependencies

### DIFF
--- a/storable-endian.cabal
+++ b/storable-endian.cabal
@@ -23,7 +23,7 @@ library
   else
     Build-Depends: base < 3
 
-  Build-Depends: haskell98, template-haskell, byteorder
+  Build-Depends: byteorder
   Exposed-Modules: Data.Storable.Endian
   Extensions: 
     MagicHash


### PR DESCRIPTION
Hi, I've removed haskell98 (build failing with ghc-7.2 on hackage) and template haskell (not used) from the dependencies, please consider pulling
